### PR TITLE
Add audio file transcription entry point

### DIFF
--- a/src/components/AudioUploader.tsx
+++ b/src/components/AudioUploader.tsx
@@ -1,15 +1,17 @@
 import React, { useCallback, useState } from 'react';
 import { Upload, FileAudio, X, Check } from 'lucide-react';
-import { transcriptionService } from '../services/transcriptionService';
+import { transcriptionService, type TranscriptionService } from '../services/transcriptionService';
 
 interface AudioUploaderProps {
   onTranscriptionComplete: (text: string) => void;
   setIsProcessing: (processing: boolean) => void;
+  service?: TranscriptionService;
 }
 
-const AudioUploader: React.FC<AudioUploaderProps> = ({ 
-  onTranscriptionComplete, 
-  setIsProcessing 
+const AudioUploader: React.FC<AudioUploaderProps> = ({
+  onTranscriptionComplete,
+  setIsProcessing,
+  service = transcriptionService,
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
@@ -28,7 +30,7 @@ const AudioUploader: React.FC<AudioUploaderProps> = ({
     try {
 
       // Transcribir el archivo de audio real
-      const transcriptionText = await transcriptionService.transcribeAudioFile(file);
+      const transcriptionText = await service.transcribeAudioFile(file);
       onTranscriptionComplete(transcriptionText);
     } catch (error) {
       console.error('Error en transcripción:', error);


### PR DESCRIPTION
## Summary
- add a simulated audio file transcription helper to the transcription service and expose related types
- allow AudioUploader to accept an injectable transcription service and use the new helper when processing files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e00e0204c8832fbc13088e78a4393b