### PR TITLE
Delay transcription tab switch until recording stops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,6 @@ function App() {
 
   const handleTranscriptionComplete = (text: string) => {
     setTranscription(text);
-    setActiveTab('transcription');
   };
 
   const handleClinicalRecordGenerated = (record: ClinicalRecord) => {
@@ -141,6 +140,7 @@ function App() {
               <VoiceRecorder
                 onTranscriptionComplete={handleTranscriptionComplete}
                 setIsProcessing={setIsProcessing}
+                onRecordingFinished={() => setActiveTab('transcription')}
               />
             )}
             

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -5,9 +5,14 @@ import { transcriptionService } from '../services/transcriptionService';
 interface VoiceRecorderProps {
   onTranscriptionComplete: (text: string) => void;
   setIsProcessing: (processing: boolean) => void;
+  onRecordingFinished?: () => void;
 }
 
-const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onTranscriptionComplete, setIsProcessing }) => {
+const VoiceRecorder: React.FC<VoiceRecorderProps> = ({
+  onTranscriptionComplete,
+  setIsProcessing,
+  onRecordingFinished,
+}) => {
   const [isRecording, setIsRecording] = useState(false);
   const [finalText, setFinalText] = useState('');
   const [interimText, setInterimText] = useState('');
@@ -171,6 +176,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onTranscriptionComplete, 
             if (prev) URL.revokeObjectURL(prev);
             return url;
           });
+          onRecordingFinished?.();
         } catch (e) {
           console.error('Error creando blob/URL de audio:', e);
           setAudioUrl(null);


### PR DESCRIPTION
## Summary
- add an optional `onRecordingFinished` callback to the voice recorder and call it after finalizing the audio blob
- update the app to switch to the transcription tab only when the recorder signals completion so interim results keep streaming

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01328ef9c832fa17d0e863099b8bc